### PR TITLE
[FEAT] 시큐리티 로그인/역할별 RESTAPI 구현

### DIFF
--- a/slash/build.gradle
+++ b/slash/build.gradle
@@ -26,7 +26,8 @@ repositories {
 dependencies {
 	// Spring Boot
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
 	//lombok
@@ -38,7 +39,7 @@ dependencies {
 
 	//Junit, Spring Security
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-//	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	//jasypt

--- a/slash/src/main/java/project/slash/security/auth/CustomUserDetailService.java
+++ b/slash/src/main/java/project/slash/security/auth/CustomUserDetailService.java
@@ -1,0 +1,27 @@
+package project.slash.security.auth;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import project.slash.user.model.User;
+import project.slash.user.repository.UserRepository;
+
+@Service
+public class CustomUserDetailService implements UserDetailsService {
+
+	private final UserRepository userRepository;
+
+	public CustomUserDetailService(UserRepository userRepository) {
+		this.userRepository = userRepository;
+	}
+
+	@Override
+	public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
+		// 데이터베이스에서 사용자 조회
+		User user = userRepository.findById(id)
+			.orElseThrow(() -> new UsernameNotFoundException("User not found: " + id));
+		return new CustomUserDetails(user);
+	}
+}

--- a/slash/src/main/java/project/slash/security/auth/CustomUserDetails.java
+++ b/slash/src/main/java/project/slash/security/auth/CustomUserDetails.java
@@ -1,0 +1,66 @@
+package project.slash.security.auth;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import project.slash.user.model.User;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class CustomUserDetails implements UserDetails {
+
+	private final User user;
+
+	public CustomUserDetails(User user) {
+		this.user = user;
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		// 사용자의 역할을 SimpleGrantedAuthority로 변환
+		return Collections.singletonList(new SimpleGrantedAuthority(user.getRole()));
+	}
+
+	@Override
+	public String getPassword() {
+		return user.getPassword();
+	}
+
+	@Override
+	public String getUsername() {
+		return user.getId();  // user_id를 username으로 사용
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+
+	public String getName() {
+		return user.getName();
+	}
+
+	public String getEmail() {
+		return user.getEmail();
+	}
+
+	public String getPhoneNum() {
+		return user.getPhoneNum();
+	}
+}

--- a/slash/src/main/java/project/slash/security/auth/UserAuthFailureHandler.java
+++ b/slash/src/main/java/project/slash/security/auth/UserAuthFailureHandler.java
@@ -1,0 +1,21 @@
+package project.slash.security.auth;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class UserAuthFailureHandler	implements AuthenticationFailureHandler {
+
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException exception) throws IOException, ServletException {
+		response.sendRedirect("/login");
+	}
+}

--- a/slash/src/main/java/project/slash/security/auth/UserAuthSuccessHandler.java
+++ b/slash/src/main/java/project/slash/security/auth/UserAuthSuccessHandler.java
@@ -1,0 +1,45 @@
+package project.slash.security.auth;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class UserAuthSuccessHandler implements AuthenticationSuccessHandler {
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) throws IOException, ServletException {
+		// 사용자의 권한 정보 가져오기
+		Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+
+		// 역할에 따라 리다이렉트할 URL 결정
+		String redirectUrl = determineRedirectUrl(authorities);
+
+		// 지정된 URL로 리다이렉트
+		response.sendRedirect(redirectUrl);
+	}
+
+	private String determineRedirectUrl(Collection<? extends GrantedAuthority> authorities) {
+		for (GrantedAuthority authority : authorities) {
+			String role = authority.getAuthority();
+			if (role.equals("ROLE_USER")) {
+				return "/user/dashboard";
+			} else if (role.equals("ROLE_CONTRACT_ADMIN")) {
+				return "/contract-admin/dashboard";
+			} else if (role.equals("ROLE_SERVICE_ADMIN")) {
+				return "/service-admin/dashboard";
+			}
+		}
+		// 기본 리다이렉트 경로 (예: 권한 없는 사용자)
+		return "/";
+	}
+}

--- a/slash/src/main/java/project/slash/security/config/SecurityConfig.java
+++ b/slash/src/main/java/project/slash/security/config/SecurityConfig.java
@@ -1,0 +1,70 @@
+package project.slash.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+import project.slash.security.auth.CustomUserDetailService;
+import project.slash.security.auth.UserAuthFailureHandler;
+import project.slash.security.auth.UserAuthSuccessHandler;
+
+@Configuration
+public class SecurityConfig {
+
+	private final CustomUserDetailService customUserDetailsService;
+	private final UserAuthSuccessHandler successHandler;
+	private final UserAuthFailureHandler failureHandler;
+
+	public SecurityConfig(CustomUserDetailService customUserDetailsService, UserAuthSuccessHandler successHandler,
+		UserAuthFailureHandler failureHandler) {
+		this.customUserDetailsService = customUserDetailsService;
+		this.successHandler = successHandler;
+		this.failureHandler = failureHandler;
+	}
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		http
+			.csrf(csrf->csrf.disable())
+			.authorizeHttpRequests((requests) -> requests
+				.requestMatchers("/","/login","/perform_login","/home", "/error").permitAll()
+				.requestMatchers("/contract-admin/**").hasRole("CONTRACT_ADMIN")
+				.requestMatchers("/service-admin/**").hasRole("SERVICE_ADMIN")
+				.requestMatchers("/user/**").hasRole("USER")
+				.anyRequest().authenticated()
+			)
+			.formLogin(form -> form
+				.loginPage("/login") // 로그인 페이지 사용 - 추후 프론트 연결
+				.loginProcessingUrl("/perform_login") // 로그인 기능을 실행 - 시큐리티 제공.
+				.usernameParameter("id")
+				.passwordParameter("password")
+				.successHandler(successHandler)  // 로그인 성공 핸들러
+				.failureHandler(failureHandler)  // 로그인 실패 핸들러
+				.permitAll()
+			)
+			.logout((logout) -> logout
+				.logoutUrl("/perform_logout")
+				.logoutSuccessUrl("/login")
+				.permitAll());
+
+		return http.build();
+	}
+
+	@Bean
+	public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
+		var builder = http.getSharedObject(AuthenticationManagerBuilder.class);
+		builder.userDetailsService(customUserDetailsService).passwordEncoder(passwordEncoder());
+		return builder.build();
+	}
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+}

--- a/slash/src/main/java/project/slash/user/controller/UserController.java
+++ b/slash/src/main/java/project/slash/user/controller/UserController.java
@@ -1,7 +1,34 @@
 package project.slash.user.controller;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class UserController {
+
+	@GetMapping("/")
+	public String homePage() {
+		return "home";
+	}
+
+	@GetMapping("/login")
+	public String loginPage() {
+		return "login-page";
+	}
+
+	@GetMapping("/contract-admin/dashboard")
+	public String contractAdminDashboard() {
+		return "contract-admin/dashboard";
+	}
+
+	@GetMapping("/service-admin/dashboard")
+	public String serviceAdminDashboard() {
+		return "service-admin/dashboard";
+	}
+
+	@GetMapping("/user/dashboard")
+	public String userDashboard() {
+		return "user/dashboard";
+	}
+
 }

--- a/slash/src/main/java/project/slash/user/model/User.java
+++ b/slash/src/main/java/project/slash/user/model/User.java
@@ -3,8 +3,15 @@ package project.slash.user.model;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
 public class User {
 	@Id
 	@Column(name = "user_id")
@@ -15,4 +22,8 @@ public class User {
 	private String email;
 	@Column(name = "phone_num")
 	private String phoneNum;
+
+	public static User from(String id, String role, String name, String password, String email, String phoneNum) {
+		return new User(id, role, name, password, email, phoneNum);
+	}
 }

--- a/slash/src/main/java/project/slash/user/service/UserService.java
+++ b/slash/src/main/java/project/slash/user/service/UserService.java
@@ -1,7 +1,33 @@
 package project.slash.user.service;
 
+import java.util.List;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import project.slash.user.model.User;
+import project.slash.user.repository.UserRepository;
+
 @Service
+@RequiredArgsConstructor
 public class UserService {
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	// 테스트용 데이터 자동 생성
+	@PostConstruct
+	public void initCustomsData() {
+		List<User> customs = List.of(
+			User.from("1", "ROLE_CONTRACT_ADMIN", "a", passwordEncoder.encode("1234"),
+				"test@test.com", "010-1111-1111"),
+			User.from("2", "ROLE_SERVICE_ADMIN", "b", passwordEncoder.encode("1234"),
+				"test@test.com", "010-1111-1111"),
+			User.from("3", "ROLE_USER", "c", passwordEncoder.encode("1234"),
+				"test@test.com", "010-1111-1111")
+		);
+
+		userRepository.saveAll(customs);
+	}
 }

--- a/slash/src/main/resources/application.yml
+++ b/slash/src/main/resources/application.yml
@@ -1,9 +1,9 @@
 spring:
   datasource:
-    driver-class-name: com.mysql.jdbc.Driver
-    url: ENC(N6G22iNIGwVJsc1B+dPUcKyr00EdPnbEHUNn85QtbCxyLitR6FcTDnr3QApRUOXwFP7RoZBF1R+ReKeEwllWPnz83Fim7Qwq4aEIz7y8ZXJjrfGNuLMZ4o4CF0gFL6iPf3nGRbZ+evU=)
-    username: ENC(rbAYXvnEtHLKTZhqKbLtHA==)
-    password: ENC(WhT4M4/oia1FZqQ/BES/jw==)
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ENC(6yjUto3Z/eV8iFQkTt4RKMB5HHEAUzMaoziqfTO5kv+wje6Xr0lxjrVB/TcOnkgkNIhYdl8yYI3VgCtyvkorTTmsOYuQPp4ovxSbwns3Vv0=)
+    username: ENC(Tg7JeTTikt6xgGQ6qWXJWQ==)
+    password: ENC(5f91ekHunQTSOjCGztNYRQ+KAbIJVg4v)
   jpa:
     open-in-view: true
     hibernate:
@@ -13,3 +13,6 @@ spring:
       hibernate.show_sql: true
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
+logging:
+  level:
+    org.springframework.security: DEBUG


### PR DESCRIPTION
## 🍀이슈 번호
- #3
## ✅ 구현 내용
- [x] **데이터 자동 생성**
  ```
  id : 1 password : 1234 role : contract_admin
  id : 2 password : 1234 role : service_admin
  id : 3 password : 1234 role : user
  ```
  <img width="523" alt="image" src="https://github.com/user-attachments/assets/823e87b1-4392-4385-9330-55336bc0d042">

- [x] **로그인 인증 시큐리티 구현**
  ```
  POST 요청 url : http://localhost:8080/perform_login 
  id, password 필요
  ```
  <img width="953" alt="image" src="https://github.com/user-attachments/assets/023ec719-6521-409f-a2d1-15dd7fb3419e">

- [x] 역할별 RESTAPI : 로그인시 각각의 String 반환
  `/contract-admin/dashboard` : contract-admin/dashboard 
  `/service-admin/dashboard` :  service-admin/dashboard
  `/user/dashboard` : user/dashboard

- [x]  페이지별 시큐리티 적용
  <img width="656" alt="image" src="https://github.com/user-attachments/assets/822b528a-d4ba-4a8b-afb2-43414cad7e7f">

## 🐳고민사항 & 기타
 - csrf 비활성화 적용했습니다.
  <img width="229" alt="image" src="https://github.com/user-attachments/assets/ab8bd476-5fa9-4d98-8349-b3ce33cf2072">


