### PR TITLE
[FIX]: DB csv  Import 를 위한 설정 변경

### DIFF
--- a/slash/src/main/java/project/slash/taskrequest/model/TaskRequest.java
+++ b/slash/src/main/java/project/slash/taskrequest/model/TaskRequest.java
@@ -40,7 +40,8 @@ public class TaskRequest extends BaseTimeEntity {
 
 	private String content;
 
-	@Column(name = "due_on_time")
+	// @Column(name = "due_on_time")
+	@Column(name = "due_on_time", columnDefinition = "TINYINT(1)")
 	private boolean dueOnTime;
 
 	@Enumerated(EnumType.STRING)

--- a/slash/src/main/resources/application.yml
+++ b/slash/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
       content-type: text/html
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ENC(Fyk575JGvKP+BPP2Rw4ks5P+KHPIioWouWI4P76Pd9bLV3dXGaIonfp11iRkLl1T13NU6S/DnGFoFLj7I1v8CUxwUFwGtoV5MtKtUYJakfdV6fm3Jn3HZv7gD4LNVbVa82fv2ACesUfBwRGWkk6F1i2UU0iibw3e9JceJRYtGAIxM76dADdEW//fFMMZH5VVRX1QvrvW0a0=)
+    url: ENC(Wl6IZoaBCe3o1mVLnxPrPL/vNeC7Gufqws4qiOKFTFqKPP4H6PuuHAfhSeTr+lzy01yiWu/GtdtK2QjOYEfJz6nmxGXoxk7xuITeSfeVRF7nco8GjJg6pF8CEtoUub1q9I0R3l7S9I6LN+fR7uO32ICWTQ1uUZ8q8jc7avMgRdi/uEahjpeqenqSGlAs6VIqFgpCiFBckmilR6QW+2aX2CilrNsj+bgtn6zD7LPUIlw=)
     username: ENC(PhyaRJCJP89U3bl2A9njuA==)
     password: ENC(RqQ+m97Mi+ianfhwxg0JI4EOZk3cPdzh)
   jpa:


### PR DESCRIPTION
## 🍀이슈 번호
- closes #133 

## ✅ 구현 내용
- [x]  명시적 타입 지정, columnDefinition 적용
- [x] JDBC URL에 tinyInt1isBit=false 적용

## 🐳고민사항 & 기타
1. JPA에서는 boolean 타입의 필드를 자동으로 TINIYINT(1)로 매핑.
2. MySQL JDBC 드라이버가 TINYINT(1)을 BIT(1)로 해석 가능
3. JDBC 드라이버 기본설정 tinyInt1isBit=true로 인함.