### PR TITLE
[FEAT]: 요청 관리 로직에 날짜 년월(required false) , 계약아이디, 계약자 권한이면 자기 요청만 볼 수 있게 설정

### DIFF
--- a/slash/src/main/java/project/slash/taskrequest/controller/TaskRequestController.java
+++ b/slash/src/main/java/project/slash/taskrequest/controller/TaskRequestController.java
@@ -1,6 +1,7 @@
 package project.slash.taskrequest.controller;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -25,11 +26,14 @@ import project.slash.taskrequest.dto.response.RequestDetailDto;
 import project.slash.taskrequest.dto.response.TaskRequestOfManagerDto;
 import project.slash.taskrequest.model.constant.RequestStatus;
 import project.slash.taskrequest.service.TaskRequestService;
+import project.slash.user.model.User;
+import project.slash.user.repository.UserRepository;
 
 @RestController
 @RequiredArgsConstructor
 public class TaskRequestController {
 	private final TaskRequestService taskRequestService;
+	private final UserRepository userRepository;
 
 	/**
 	 * 요청 생성 메서드입니다.
@@ -126,15 +130,18 @@ public class TaskRequestController {
 		@RequestParam(required = false) RequestStatus status,
 		@RequestParam(required = false) String keyword,
 		@RequestParam(defaultValue = "1") int page,
-		@RequestParam(defaultValue = "5") int size
+		@RequestParam(defaultValue = "5") int size,
+		@RequestParam("year") int year,
+		@RequestParam("month") int month,
+		@RequestParam("contractId") long contractId,
+		@Login String user
 	) {
 		Pageable pageable = PageRequest.of(page - 1, size);
 
 		// 서비스 메서드를 호출하여 RequestManagementResponseDto 객체를 받음
 		RequestManagementResponseDto responseData = taskRequestService.findFilteredRequests(
-			equipmentName, type, taskDetail, status, keyword, pageable
+			equipmentName, type, taskDetail, status, keyword, pageable,year,month,contractId,user
 		);
-
 
 		return BaseResponse.ok(responseData);
 	}

--- a/slash/src/main/java/project/slash/taskrequest/dto/request/RequestManagementDto.java
+++ b/slash/src/main/java/project/slash/taskrequest/dto/request/RequestManagementDto.java
@@ -19,8 +19,10 @@ public class RequestManagementDto {
 	private String type;
 	private String taskDetail;
 	private Long id;
+	private Long contractId;
 	private String requesterName;
 	private String managerName;
+	private String managerId;
 	private LocalDateTime createTime;
 	private LocalDateTime updateTime;
 

--- a/slash/src/main/java/project/slash/taskrequest/repository/TaskRequestRepositoryCustom.java
+++ b/slash/src/main/java/project/slash/taskrequest/repository/TaskRequestRepositoryCustom.java
@@ -24,7 +24,8 @@ public interface TaskRequestRepositoryCustom {
 	List<TaskRequestOfManagerDto> findTaskRequestOfManager();
 
 	Page<RequestManagementDto> findFilteredRequests(String equipmentName, String type,
-		String taskDetail, RequestStatus status, String keyword, Pageable pageable);
+		String taskDetail, RequestStatus status, String keyword, Pageable pageable, int year, int month,
+		Long contractId, String user,String role);
 
 	void updateManagerByRequestId(Long requestId, String managerId);
 

--- a/slash/src/main/java/project/slash/taskrequest/service/TaskRequestService.java
+++ b/slash/src/main/java/project/slash/taskrequest/service/TaskRequestService.java
@@ -6,6 +6,7 @@ import static project.slash.taskrequest.model.constant.RequestStatus.*;
 import static project.slash.user.exception.UserErrorCode.*;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -155,10 +156,18 @@ public class TaskRequestService {
 		String taskDetail,
 		RequestStatus status,
 		String keyword,
-		Pageable pageable
+		Pageable pageable, int year, int month, Long contractId, String user
 	) {
+
+
+		Optional<User> usr=userRepository.findById(user);
+		String role = usr.get().getRole();
+
 		Page<RequestManagementDto> taskResponseRequestDtos = taskRequestRepository.findFilteredRequests(
-			equipmentName, type, taskDetail, status, keyword, pageable);
+			equipmentName, type, taskDetail, status, keyword, pageable, year, month, contractId,
+			user,role);
+
+
 
 		return new RequestManagementResponseDto(
 			taskResponseRequestDtos.getContent(),


### PR DESCRIPTION
## 🍀이슈 번호
- closes #134 

## ✅ 구현 내용
- [x] 요청 관리 로직에 날짜 년월(required false) , 계약아이디, 계약자 권한이면 자기 요청만 볼 수 있게 설정

## 🐳고민사항 & 기타
